### PR TITLE
Add note on Java memory limit settings

### DIFF
--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -48,6 +48,7 @@ Please make sure to compare your configuration against the current configuration
   now specified as a string in the TOML file and not as a separate file (usually `acl.xml`) anymore. Finally,
   the variables passed into the Mustache ACL template have changed. For more information, see
   [this document](https://github.com/elan-ev/opencast-studio/blob/2020-09-14/CONFIGURATION.md).
+- In larger installations: raise the Java memory limits in `/usr/share/opencast/bin/setenv` and `/etc/elasticsearch/jvm.options`
 
 
 Install and configure a standalone Elasticsearch node


### PR DESCRIPTION
Omitting this step leads to failures during the indexing run. Both memory settings had to be raised in our case. Settings were 12 GiB for Opencast and 2 GiB for elasticsearch.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
